### PR TITLE
refactor: replace panics with returned errors

### DIFF
--- a/changelog/changelog.go
+++ b/changelog/changelog.go
@@ -189,12 +189,15 @@ func GetUpdatedChangelog(
 	beforeTag string,
 	afterTag string,
 ) (metadata vcs.ReleaseMetadata, updatedChangelog string, err error) {
-	commits, err := vcs.FetchCommitsByTag(config, commitCfg, repoPath, beforeTag, afterTag)
+	commits, stats, err := vcs.FetchCommitsByTag(config, commitCfg, repoPath, beforeTag, afterTag)
 	if err != nil {
 		return vcs.ReleaseMetadata{}, "", fmt.Errorf("failed to fetch commit messages from repo: %s: %v", repoPath, err)
 	}
 	if len(*commits) == 0 {
-		return vcs.ReleaseMetadata{}, "", fmt.Errorf("no changes since start tag")
+		return vcs.ReleaseMetadata{}, "", &NoChangesError{
+			StartTag:      afterTag,
+			ExcludedCount: stats.Excluded,
+		}
 	}
 
 	currentVersion, vPrefix, err := semver.GetCurrentVersion(repoPath, orderBy)

--- a/changelog/changelog.go
+++ b/changelog/changelog.go
@@ -197,7 +197,10 @@ func GetUpdatedChangelog(
 		return vcs.ReleaseMetadata{}, "", fmt.Errorf("no changes since start tag")
 	}
 
-	currentVersion, vPrefix := semver.GetCurrentVersion(repoPath, orderBy)
+	currentVersion, vPrefix, err := semver.GetCurrentVersion(repoPath, orderBy)
+	if err != nil {
+		return vcs.ReleaseMetadata{}, "", fmt.Errorf("failed to get current version: %w", err)
+	}
 
 	var nextVersion string
 	var releaseUnreleased bool

--- a/changelog/changelog_test.go
+++ b/changelog/changelog_test.go
@@ -212,7 +212,7 @@ func TestGetUpdatedChangelog(t *testing.T) {
 			wantMetadata:         vcs.ReleaseMetadata{},
 			wantUpdatedChangelog: "",
 			wantErr:              true,
-			errMessage:           "no changes since start tag",
+			errMessage:           "no commits since 0.1.0",
 		},
 		{
 			name: "unreleased changes",

--- a/changelog/errors.go
+++ b/changelog/errors.go
@@ -1,0 +1,41 @@
+/*
+Copyright © 2023 Pete Cornish <outofcoffee@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package changelog
+
+import "fmt"
+
+// NoChangesError is returned when no commits are found between the start tag
+// and HEAD. ExcludedCount reports how many commits were dropped by the
+// configured ignore patterns; when non-zero the user is most likely hitting
+// an over-broad ignore regex.
+type NoChangesError struct {
+	StartTag      string
+	ExcludedCount int
+}
+
+func (e *NoChangesError) Error() string {
+	switch {
+	case e.ExcludedCount > 0 && e.StartTag != "":
+		return fmt.Sprintf(
+			"no eligible commits since %s — %d commit(s) were excluded by ignore patterns in since.yaml",
+			e.StartTag, e.ExcludedCount,
+		)
+	case e.ExcludedCount > 0:
+		return fmt.Sprintf(
+			"no eligible commits found — %d commit(s) were excluded by ignore patterns in since.yaml",
+			e.ExcludedCount,
+		)
+	case e.StartTag != "":
+		return fmt.Sprintf("no commits since %s", e.StartTag)
+	default:
+		return "no commits found"
+	}
+}

--- a/changelog/read.go
+++ b/changelog/read.go
@@ -39,7 +39,7 @@ func ParseChangelog(path string, version string, includeHeader bool) ([]string, 
 	if err != nil {
 		return nil, err
 	}
-	return readChanges(lines, version, includeHeader), nil
+	return readChanges(lines, version, includeHeader)
 }
 
 // ReadFile loads a changelog file at the given path and returns a slice of strings containing each line.
@@ -62,7 +62,7 @@ func ReadFile(path string) ([]string, error) {
 
 // readChanges parses a changelog and returns all content starting with the h2 for the specified version,
 // before the next h2, or the end of the file. If no version is specified, the first h2 is used.
-func readChanges(lines []string, version string, includeHeader bool) []string {
+func readChanges(lines []string, version string, includeHeader bool) ([]string, error) {
 	// find the first h2
 	firstH2 := 0
 	for i, line := range lines {
@@ -78,7 +78,10 @@ func readChanges(lines []string, version string, includeHeader bool) []string {
 		}
 	}
 	if firstH2 == 0 {
-		panic(fmt.Sprintf("could not find version %s in changelog", version))
+		if version == "" {
+			return nil, fmt.Errorf("changelog contains no version sections")
+		}
+		return nil, fmt.Errorf("could not find version %s in changelog", version)
 	}
 	// find the next h2, or the end of the file
 	nextH2 := len(lines) - firstH2 - 1
@@ -88,5 +91,5 @@ func readChanges(lines []string, version string, includeHeader bool) []string {
 			break
 		}
 	}
-	return lines[firstH2 : firstH2+nextH2]
+	return lines[firstH2 : firstH2+nextH2], nil
 }

--- a/changelog/read_test.go
+++ b/changelog/read_test.go
@@ -130,7 +130,10 @@ func Test_readChanges_firstVersion(t *testing.T) {
 		"## [0.9.0] - 2023-12-01",
 		"- fix: bar",
 	}
-	got := readChanges(lines, "", false)
+	got, err := readChanges(lines, "", false)
+	if err != nil {
+		t.Fatalf("readChanges() error = %v", err)
+	}
 	want := []string{"### Added", "- feat: foo"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("readChanges() = %v, want %v", got, want)

--- a/changelog/write.go
+++ b/changelog/write.go
@@ -24,25 +24,27 @@ import (
 
 // WriteChangelog updates the changelog file with the given content.
 func WriteChangelog(changelogFile string, updatedChangelog string) error {
-	tempChangelog := writeTempChangelog(updatedChangelog)
-	err := os.Rename(tempChangelog, changelogFile)
+	tempChangelog, err := writeTempChangelog(updatedChangelog)
 	if err != nil {
-		panic(fmt.Errorf("failed to rename temp file: %s: %w", tempChangelog, err))
+		return err
+	}
+	if err := os.Rename(tempChangelog, changelogFile); err != nil {
+		return fmt.Errorf("failed to rename temp file: %s: %w", tempChangelog, err)
 	}
 	logrus.Debugf("updated changelog: %s", changelogFile)
-	return err
+	return nil
 }
 
 // writeTempChangelog writes the updated changelog to a temp file and returns the path to the temp file.
-func writeTempChangelog(content string) string {
+func writeTempChangelog(content string) (string, error) {
 	temp, err := os.CreateTemp(os.TempDir(), "changelog*.md")
 	if err != nil {
-		panic(fmt.Errorf("failed to create temp file: %w", err))
+		return "", fmt.Errorf("failed to create temp file: %w", err)
 	}
-	_, err = temp.WriteString(content + "\n")
-	if err != nil {
-		panic(fmt.Errorf("failed to write to temp file: %w", err))
+	if _, err := temp.WriteString(content + "\n"); err != nil {
+		_ = temp.Close()
+		return "", fmt.Errorf("failed to write to temp file: %w", err)
 	}
 	_ = temp.Close()
-	return temp.Name()
+	return temp.Name(), nil
 }

--- a/cmd/changelog.go
+++ b/cmd/changelog.go
@@ -45,31 +45,31 @@ func init() {
 	changelogCmd.PersistentFlags().BoolVar(&changelogArgs.excludeTagCommits, "exclude-tag-commits", false, "Exclude tag commits in the changelog")
 }
 
-func getWorkingDir() string {
+func getWorkingDir() (string, error) {
 	workingDir, err := os.Getwd()
 	if err != nil {
-		panic(fmt.Errorf("failed to get working directory: %v", err))
+		return "", fmt.Errorf("failed to get working directory: %w", err)
 	}
-	return workingDir
+	return workingDir, nil
 }
 
 // writeOutput writes the output to the output file, or stdout if not set.
-func writeOutput(output string) {
+func writeOutput(output string) error {
 	outputFile := changelogArgs.outputFile
 	if outputFile == "" {
 		logrus.Warn("no output file specified, writing to stdout")
 		fmt.Println(output)
-	} else {
-		logrus.Tracef("writing output to file: %s", outputFile)
-		file, err := os.Create(outputFile)
-		if err != nil {
-			panic(fmt.Errorf("failed to create output file: %s: %v", outputFile, err))
-		}
-		defer file.Close()
-
-		_, err = file.WriteString(output)
-		if err != nil {
-			panic(fmt.Errorf("failed to write output to file: %v", err))
-		}
+		return nil
 	}
+	logrus.Tracef("writing output to file: %s", outputFile)
+	file, err := os.Create(outputFile)
+	if err != nil {
+		return fmt.Errorf("failed to create output file: %s: %w", outputFile, err)
+	}
+	defer file.Close()
+
+	if _, err := file.WriteString(output); err != nil {
+		return fmt.Errorf("failed to write output to file: %w", err)
+	}
+	return nil
 }

--- a/cmd/changelog_extract.go
+++ b/cmd/changelog_extract.go
@@ -33,14 +33,20 @@ var extractCmd = &cobra.Command{
 	Long: `Extracts changes for a given version in a changelog file.
 If no version is specified, the most recent version is used.
 Prints it to stdout, or output-file, if specified.`,
-	Args: cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
-		changelogFile := changelog.ResolveChangelogFile(getWorkingDir(), changelogArgs.changelogFile)
+	Args:          cobra.NoArgs,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		workingDir, err := getWorkingDir()
+		if err != nil {
+			return err
+		}
+		changelogFile := changelog.ResolveChangelogFile(workingDir, changelogArgs.changelogFile)
 		changes, err := printChanges(changelogFile, extractArgs.version, extractArgs.includeHeader)
 		if err != nil {
-			panic(err)
+			return err
 		}
-		writeOutput(changes)
+		return writeOutput(changes)
 	},
 }
 

--- a/cmd/changelog_generate.go
+++ b/cmd/changelog_generate.go
@@ -36,8 +36,10 @@ var generateCmd = &cobra.Command{
 	Long: `Generates a new changelog based on an existing changelog file,
 adding a new release section using the commits since the last release,
 then prints it to stdout, or output-file, if specified.`,
-	Args: cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:          cobra.NoArgs,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		changelogFile := changelog.ResolveChangelogFile(
 			generateArgs.repoPath,
 			changelogArgs.changelogFile,
@@ -46,7 +48,7 @@ then prints it to stdout, or output-file, if specified.`,
 			ExcludeTagCommits: changelogArgs.excludeTagCommits,
 			UniqueOnly:        generateArgs.unique,
 		}
-		generateChangelog(
+		return generateChangelog(
 			commitCfg,
 			changelogFile,
 			vcs.TagOrderBy(generateArgs.orderBy),
@@ -68,20 +70,20 @@ func generateChangelog(
 	changelogFile string,
 	orderBy vcs.TagOrderBy,
 	repoPath string,
-) {
+) error {
 	config, err := cfg.LoadConfig(repoPath)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	latestTag, err := vcs.GetLatestTag(repoPath, orderBy)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	_, updated, err := changelog.GetUpdatedChangelog(config, commitCfg, changelogFile, orderBy, repoPath, "", latestTag)
 	if err != nil {
-		panic(err)
+		return err
 	}
-	writeOutput(updated)
+	return writeOutput(updated)
 }

--- a/cmd/changelog_init.go
+++ b/cmd/changelog_init.go
@@ -32,11 +32,13 @@ var initArgs struct {
 
 // initCmd represents the init command
 var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Initialise a new changelog file",
-	Long:  `Initialises a new changelog file based on the specified git repository.`,
-	Args:  cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:           "init",
+	Short:         "Initialise a new changelog file",
+	Long:          `Initialises a new changelog file based on the specified git repository.`,
+	Args:          cobra.NoArgs,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		changelogFile := changelog.ResolveChangelogFile(
 			initArgs.repoPath,
 			changelogArgs.changelogFile,
@@ -45,7 +47,7 @@ var initCmd = &cobra.Command{
 			ExcludeTagCommits: changelogArgs.excludeTagCommits,
 			UniqueOnly:        initArgs.unique,
 		}
-		initChangelog(
+		return initChangelog(
 			commitCfg,
 			changelogFile,
 			vcs.TagOrderBy(initArgs.orderBy),
@@ -62,15 +64,18 @@ func init() {
 	initCmd.Flags().BoolVar(&initArgs.unique, "unique", true, "De-duplicate commit messages")
 }
 
-func initChangelog(commitCfg vcs.CommitConfig, changelogFile string, orderBy vcs.TagOrderBy, repoPath string) {
+func initChangelog(commitCfg vcs.CommitConfig, changelogFile string, orderBy vcs.TagOrderBy, repoPath string) error {
 	config, err := cfg.LoadConfig(repoPath)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	newChangelog, err := changelog.InitChangelog(config, commitCfg, changelogFile, orderBy, repoPath)
 	if err != nil {
-		panic(err)
+		return err
 	}
-	writeOutput(newChangelog)
+	if err := writeOutput(newChangelog); err != nil {
+		return err
+	}
 	logrus.Infof("initialised changelog file '%s'", changelogFile)
+	return nil
 }

--- a/cmd/changelog_update.go
+++ b/cmd/changelog_update.go
@@ -36,14 +36,16 @@ var updateCmd = &cobra.Command{
 	Short: "Write updated changelog based on changes since last release",
 	Long: `Updates the existing changelog file with a new release section,
 using the commits since the last release.`,
-	Args: cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:          cobra.NoArgs,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		changelogFile := changelog.ResolveChangelogFile(updateArgs.repoPath, changelogArgs.changelogFile)
 		commitCfg := vcs.CommitConfig{
 			ExcludeTagCommits: changelogArgs.excludeTagCommits,
 			UniqueOnly:        updateArgs.unique,
 		}
-		updateChangelog(
+		return updateChangelog(
 			commitCfg,
 			changelogFile,
 			vcs.TagOrderBy(updateArgs.orderBy),
@@ -65,24 +67,24 @@ func updateChangelog(
 	changelogFile string,
 	orderBy vcs.TagOrderBy,
 	repoPath string,
-) {
+) error {
 	config, err := cfg.LoadConfig(repoPath)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	latestTag, err := vcs.GetLatestTag(repoPath, orderBy)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	_, updated, err := changelog.GetUpdatedChangelog(config, commitCfg, changelogFile, orderBy, repoPath, "", latestTag)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
-	err = changelog.WriteChangelog(changelogFile, updated)
-	if err != nil {
-		panic(fmt.Errorf("failed to update changelog: %w", err))
+	if err := changelog.WriteChangelog(changelogFile, updated); err != nil {
+		return fmt.Errorf("failed to update changelog: %w", err)
 	}
+	return nil
 }

--- a/cmd/project_changes.go
+++ b/cmd/project_changes.go
@@ -83,7 +83,7 @@ func listCommits(
 		afterTag = tag
 	}
 
-	commits, err := vcs.FetchCommitsByTag(config, commitCfg, repoPath, "", afterTag)
+	commits, _, err := vcs.FetchCommitsByTag(config, commitCfg, repoPath, "", afterTag)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/project_changes.go
+++ b/cmd/project_changes.go
@@ -34,7 +34,9 @@ var changesCmd = &cobra.Command{
 	Short: "List the changes since the last release",
 	Long: `Reads the commit history for the current git repository, starting
 from the most recent tag. Lists the commits categorised by their type.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		commitCfg := vcs.CommitConfig{
 			ExcludeTagCommits: projectArgs.excludeTagCommits,
 			UniqueOnly:        changesArgs.unique,
@@ -46,9 +48,10 @@ from the most recent tag. Lists the commits categorised by their type.`,
 			vcs.TagOrderBy(projectArgs.orderBy),
 		)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		fmt.Println(changes)
+		return nil
 	},
 }
 
@@ -66,14 +69,14 @@ func listCommits(
 ) (string, error) {
 	config, err := cfg.LoadConfig(repoPath)
 	if err != nil {
-		panic(err)
+		return "", err
 	}
 
 	var afterTag string
 	if tag == "" {
 		latestTag, err := vcs.GetLatestTag(repoPath, orderBy)
 		if err != nil {
-			panic(err)
+			return "", err
 		}
 		afterTag = latestTag
 	} else {

--- a/cmd/project_release.go
+++ b/cmd/project_release.go
@@ -39,14 +39,16 @@ using the commits since the last release.
 
 The changelog is then committed and a new tag is created
 with the new version.`,
-	Args: cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:          cobra.NoArgs,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		changelogFile := changelog.ResolveChangelogFile(projectArgs.repoPath, changelogArgs.changelogFile)
 		commitCfg := vcs.CommitConfig{
 			ExcludeTagCommits: projectArgs.excludeTagCommits,
 			UniqueOnly:        releaseArgs.unique,
 		}
-		release(
+		return release(
 			commitCfg,
 			changelogFile,
 			vcs.TagOrderBy(projectArgs.orderBy),
@@ -67,23 +69,23 @@ func release(
 	changelogFile string,
 	orderBy vcs.TagOrderBy,
 	repoPath string,
-) {
+) error {
 	config, err := cfg.LoadConfig(repoPath)
 	if err != nil {
-		panic(fmt.Errorf("failed to load config: %w", err))
+		return fmt.Errorf("failed to load config: %w", err)
 	}
-	if err = vcs.CheckBranch(repoPath, config); err != nil {
-		panic(err)
+	if err := vcs.CheckBranch(repoPath, config); err != nil {
+		return err
 	}
 
 	latestTag, err := vcs.GetLatestTag(repoPath, orderBy)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	metadata, updatedChangelog, err := changelog.GetUpdatedChangelog(config, commitCfg, changelogFile, orderBy, repoPath, "", latestTag)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	version := metadata.NewVersion
@@ -91,30 +93,27 @@ func release(
 		version = "v" + version
 	}
 
-	err = hooks.ExecuteHooks(config, hooks.Before, metadata)
-	if err != nil {
-		panic(fmt.Errorf("failed to execute hooks before release: %w", err))
+	if err := hooks.ExecuteHooks(config, hooks.Before, metadata); err != nil {
+		return fmt.Errorf("failed to execute hooks before release: %w", err)
 	}
 
-	err = changelog.WriteChangelog(changelogFile, updatedChangelog)
-	if err != nil {
-		panic(fmt.Errorf("failed to update changelog: %w", err))
+	if err := changelog.WriteChangelog(changelogFile, updatedChangelog); err != nil {
+		return fmt.Errorf("failed to update changelog: %w", err)
 	}
 
 	hash, err := vcs.CommitChangelog(repoPath, changelogFile, version)
 	if err != nil {
-		panic(fmt.Errorf("failed to commit changelog: %w", err))
+		return fmt.Errorf("failed to commit changelog: %w", err)
 	}
 
-	err = vcs.TagRelease(repoPath, hash, version)
-	if err != nil {
-		panic(fmt.Errorf("failed to tag release commit: %s: %w", hash, err))
+	if err := vcs.TagRelease(repoPath, hash, version); err != nil {
+		return fmt.Errorf("failed to tag release commit: %s: %w", hash, err)
 	}
 
-	err = hooks.ExecuteHooks(config, hooks.After, metadata)
-	if err != nil {
-		panic(fmt.Errorf("failed to execute hooks after release: %w", err))
+	if err := hooks.ExecuteHooks(config, hooks.After, metadata); err != nil {
+		return fmt.Errorf("failed to execute hooks after release: %w", err)
 	}
 
 	fmt.Printf("released version %s\n", version)
+	return nil
 }

--- a/cmd/project_version.go
+++ b/cmd/project_version.go
@@ -40,23 +40,29 @@ based on the changes.
 
 Changes influence the version according to
 conventional commits: https://www.conventionalcommits.org/en/v1.0.0/`,
-	Args: cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	Args:          cobra.NoArgs,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		commitCfg := vcs.CommitConfig{
 			ExcludeTagCommits: projectArgs.excludeTagCommits,
 			UniqueOnly:        versionArgs.unique,
 		}
-		version := printVersion(
+		version, err := printVersion(
 			commitCfg,
 			projectArgs.repoPath,
 			projectArgs.tag,
 			vcs.TagOrderBy(projectArgs.orderBy),
 			versionArgs.current,
 		)
+		if err != nil {
+			return err
+		}
 		if version == "" {
 			os.Exit(1)
 		}
 		fmt.Println(version)
+		return nil
 	},
 }
 
@@ -73,25 +79,28 @@ func printVersion(
 	tag string,
 	orderBy vcs.TagOrderBy,
 	current bool,
-) string {
-	currentVersion, vPrefix := semver.GetCurrentVersion(repoPath, orderBy)
+) (string, error) {
+	currentVersion, vPrefix, err := semver.GetCurrentVersion(repoPath, orderBy)
+	if err != nil {
+		return "", err
+	}
 	if current {
 		if vPrefix {
 			currentVersion = "v" + currentVersion
 		}
-		return currentVersion
+		return currentVersion, nil
 	}
 
 	config, err := cfg.LoadConfig(repoPath)
 	if err != nil {
-		panic(err)
+		return "", err
 	}
 
 	var afterTag string
 	if tag == "" {
 		latestTag, err := vcs.GetLatestTag(repoPath, orderBy)
 		if err != nil {
-			panic(err)
+			return "", err
 		}
 		afterTag = latestTag
 	} else {
@@ -100,7 +109,7 @@ func printVersion(
 
 	commits, err := vcs.FetchCommitMessages(config, commitCfg, repoPath, "", afterTag)
 	if err != nil {
-		panic(err)
+		return "", err
 	}
-	return semver.GetNextVersion(currentVersion, vPrefix, commits)
+	return semver.GetNextVersion(currentVersion, vPrefix, commits), nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"os"
@@ -44,8 +45,8 @@ func init() {
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, "Error: "+err.Error())
 		os.Exit(1)
 	}
 }

--- a/semver/versions.go
+++ b/semver/versions.go
@@ -35,17 +35,17 @@ const (
 )
 
 // GetCurrentVersion gets the current version from the repo.
-func GetCurrentVersion(repoPath string, orderBy vcs.TagOrderBy) (version string, vPrefix bool) {
-	version, err := vcs.GetLatestTag(repoPath, orderBy)
+func GetCurrentVersion(repoPath string, orderBy vcs.TagOrderBy) (version string, vPrefix bool, err error) {
+	version, err = vcs.GetLatestTag(repoPath, orderBy)
 	if err != nil {
-		panic(err)
+		return "", false, err
 	}
 	if strings.HasPrefix(version, "v") {
 		version = strings.TrimPrefix(version, "v")
 		vPrefix = true
 	}
 	logrus.Tracef("current version: %s", version)
-	return version, vPrefix
+	return version, vPrefix, nil
 }
 
 // GetNextVersion gets the next version based on the current version and the commit messages.

--- a/vcs/commits.go
+++ b/vcs/commits.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vcs
 
 import (
+	"fmt"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
@@ -97,7 +98,11 @@ func fetchCommitsBetween(
 ) (*[]TagCommits, error) {
 	var excludes []*regexp.Regexp
 	for _, i := range config.Ignore {
-		excludes = append(excludes, regexp.MustCompile(i))
+		pattern, err := regexp.Compile(i)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ignore pattern %q in since.yaml: %w", i, err)
+		}
+		excludes = append(excludes, pattern)
 	}
 
 	r, err := git.PlainOpen(repoPath)
@@ -138,6 +143,9 @@ func fetchCommitsBetween(
 	}
 
 	allTags, err := listAllTags(r)
+	if err != nil {
+		return nil, err
+	}
 
 	commits, err := r.Log(&git.LogOptions{})
 	if err != nil {

--- a/vcs/commits.go
+++ b/vcs/commits.go
@@ -37,6 +37,15 @@ type CommitConfig struct {
 	UniqueOnly        bool
 }
 
+// FilterStats captures how many commits were considered when fetching
+// commits between two tags, and how many of those were excluded by the
+// configured ignore patterns. It is useful for explaining why a fetch
+// returned no results.
+type FilterStats struct {
+	Considered int
+	Excluded   int
+}
+
 // FetchCommitMessages returns a slice of commit messages between the given tags.
 // If beforeTag is empty, then HEAD is used.
 // If afterTag is empty, the oldest commit is used.
@@ -47,7 +56,7 @@ func FetchCommitMessages(
 	beforeTag string,
 	afterTag string,
 ) ([]string, error) {
-	commits, err := FetchCommitsByTag(config, commitCfg, repoPath, beforeTag, afterTag)
+	commits, _, err := FetchCommitsByTag(config, commitCfg, repoPath, beforeTag, afterTag)
 	if err != nil {
 		return nil, err
 	}
@@ -58,24 +67,26 @@ func FetchCommitMessages(
 // The key is the tag metadata, and the value is a slice of commit messages.
 // If beforeTag is empty, then HEAD is used.
 // If afterTag is empty, the oldest commit is used.
+// The returned FilterStats describes how many commits were considered and
+// how many were dropped by the configured ignore patterns.
 func FetchCommitsByTag(
 	config cfg.SinceConfig,
 	commitCfg CommitConfig,
 	repoPath string,
 	beforeTag string,
 	afterTag string,
-) (*[]TagCommits, error) {
-	commits, err := fetchCommitsBetween(config, commitCfg, repoPath, beforeTag, afterTag)
+) (*[]TagCommits, FilterStats, error) {
+	commits, stats, err := fetchCommitsBetween(config, commitCfg, repoPath, beforeTag, afterTag)
 	if err != nil {
-		return nil, err
+		return nil, FilterStats{}, err
 	}
 
 	if logrus.IsLevelEnabled(logrus.TraceLevel) {
 		logrus.Tracef("commits by tag: %v", commits)
 	} else {
-		logrus.Debugf("fetched %d tags\n", len(*commits))
+		logrus.Debugf("fetched %d tags (considered %d commits, excluded %d)", len(*commits), stats.Considered, stats.Excluded)
 	}
-	return commits, nil
+	return commits, stats, nil
 }
 
 func FlattenCommits(tags *[]TagCommits) []string {
@@ -95,34 +106,34 @@ func fetchCommitsBetween(
 	repoPath string,
 	beforeTag string,
 	afterTag string,
-) (*[]TagCommits, error) {
+) (*[]TagCommits, FilterStats, error) {
 	var excludes []*regexp.Regexp
 	for _, i := range config.Ignore {
 		pattern, err := regexp.Compile(i)
 		if err != nil {
-			return nil, fmt.Errorf("invalid ignore pattern %q in since.yaml: %w", i, err)
+			return nil, FilterStats{}, fmt.Errorf("invalid ignore pattern %q in since.yaml: %w", i, err)
 		}
 		excludes = append(excludes, pattern)
 	}
 
 	r, err := git.PlainOpen(repoPath)
 	if err != nil {
-		return nil, err
+		return nil, FilterStats{}, err
 	}
 
 	var beforeCommit *object.Commit
 	if beforeTag != "" {
 		beforeTagMeta, err := r.Tag(beforeTag)
 		if err != nil {
-			return nil, err
+			return nil, FilterStats{}, err
 		}
 		hash, err := getCommitHashForTag(beforeTagMeta, r)
 		if err != nil {
-			return nil, err
+			return nil, FilterStats{}, err
 		}
 		beforeCommit, err = r.CommitObject(hash)
 		if err != nil {
-			return nil, err
+			return nil, FilterStats{}, err
 		}
 	}
 
@@ -130,34 +141,34 @@ func fetchCommitsBetween(
 	if afterTag != "" {
 		afterTagMeta, err := r.Tag(afterTag)
 		if err != nil {
-			return nil, err
+			return nil, FilterStats{}, err
 		}
 		hash, err := getCommitHashForTag(afterTagMeta, r)
 		if err != nil {
-			return nil, err
+			return nil, FilterStats{}, err
 		}
 		afterCommit, err = r.CommitObject(hash)
 		if err != nil {
-			return nil, err
+			return nil, FilterStats{}, err
 		}
 	}
 
 	allTags, err := listAllTags(r)
 	if err != nil {
-		return nil, err
+		return nil, FilterStats{}, err
 	}
 
 	commits, err := r.Log(&git.LogOptions{})
 	if err != nil {
-		return nil, err
+		return nil, FilterStats{}, err
 	}
 
-	tagCommits, err := processCommits(commitCfg, beforeCommit, afterCommit, commits, allTags, excludes)
+	tagCommits, stats, err := processCommits(commitCfg, beforeCommit, afterCommit, commits, allTags, excludes)
 	if err != nil {
-		return nil, err
+		return nil, FilterStats{}, err
 	}
 
-	return tagCommits, nil
+	return tagCommits, stats, nil
 }
 
 func processCommits(
@@ -167,8 +178,9 @@ func processCommits(
 	commits object.CommitIter,
 	allTags map[string]*TagMeta,
 	excludes []*regexp.Regexp,
-) (*[]TagCommits, error) {
+) (*[]TagCommits, FilterStats, error) {
 	var tagCommits []TagCommits
+	var stats FilterStats
 
 	currentTag := TagMeta{
 		Name: UnreleasedVersionName,
@@ -219,8 +231,10 @@ func processCommits(
 			return nil
 		}
 
+		stats.Considered++
 		longMessage := c.Message
 		if !shouldInclude(longMessage, excludes) {
+			stats.Excluded++
 			return nil
 		}
 		message := getShortMessage(longMessage)
@@ -229,13 +243,13 @@ func processCommits(
 	})
 
 	if err != nil {
-		return nil, err
+		return nil, FilterStats{}, err
 	}
 
 	// final tag
 	appendCurrentTag()
 
-	return &tagCommits, nil
+	return &tagCommits, stats, nil
 }
 
 // listAllTags returns a map of tag hashes to tag metadata.

--- a/vcs/fetch_test.go
+++ b/vcs/fetch_test.go
@@ -42,7 +42,7 @@ func TestFetchCommitMessages_allCommits(t *testing.T) {
 func TestFetchCommitsByTag(t *testing.T) {
 	repoDir := createTestRepo(t)
 
-	tagCommits, err := FetchCommitsByTag(cfg.SinceConfig{}, CommitConfig{}, repoDir, "", "0.0.1")
+	tagCommits, _, err := FetchCommitsByTag(cfg.SinceConfig{}, CommitConfig{}, repoDir, "", "0.0.1")
 	if err != nil {
 		t.Fatalf("FetchCommitsByTag() error = %v", err)
 	}

--- a/vcs/tags.go
+++ b/vcs/tags.go
@@ -131,7 +131,7 @@ func getEndTag(repoPath string, endType endTagType, orderBy TagOrderBy) (string,
 				}
 
 			default:
-				panic("unknown tag order by: " + orderBy)
+				return fmt.Errorf("unknown tag order by: %s", orderBy)
 			}
 		}
 
@@ -143,6 +143,10 @@ func getEndTag(repoPath string, endType endTagType, orderBy TagOrderBy) (string,
 	})
 	if err != nil {
 		return "", err
+	}
+
+	if candidateTag == nil {
+		return "", fmt.Errorf("no tags found in repository at %s", repoPath)
 	}
 
 	tagName := candidateTag.Name().Short()


### PR DESCRIPTION
Replaces every production-code `panic` in the since CLI with returned errors and gives the "no changes since tag" failure a friendly, actionable message.

## Summary
- Library helpers in `changelog`, `semver`, and `vcs` now return errors instead of panicking; every cobra subcommand uses `RunE` with `SilenceUsage` / `SilenceErrors`.
- `cmd/root.go` prints failures as a single `Error: ...` line on stderr and exits non-zero — no more Go stack traces leaking to users.
- New `changelog.NoChangesError` is returned when nothing remains after filtering, e.g. `no eligible commits since v1.17.4 — 1 commit(s) were excluded by ignore patterns in since.yaml`. A new `vcs.FilterStats` carries the considered/excluded counts up from `processCommits`.
- Tightens latent crashes: invalid `ignore:` regexes in `since.yaml` now report `invalid ignore pattern …` instead of panicking via `regexp.MustCompile`, and a repo with no tags returns `no tags found in repository …` instead of dereferencing a nil tag reference.

## Implementation details
The refactor was split into two commits: the mechanical panic-removal pass, then the UX layer that introduces `NoChangesError` and the filter-stats plumbing. Keeping them apart makes the second commit easy to review on its own — it is the only part that changes behaviour beyond "no more stack traces".

`FetchCommitsByTag` gains a third return value (`FilterStats`); existing callers that don't care discard it with `_`. `processCommits` increments the `Considered` and `Excluded` counters only for non-tag commits past the skip window, so the counts reflect what the user actually intends to see in the changelog rather than the raw `git log` count.