### PR TITLE
feat: support --version flag to print built version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,8 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X github.com/release-tools/since/cmd.Version={{ .Version }}
     goos:
       - linux
       - windows

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.20 AS builder
 
+ARG VERSION=dev
 WORKDIR /src
 
 COPY go.mod go.sum ./
@@ -7,7 +8,7 @@ RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /since
+RUN CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/release-tools/since/cmd.Version=${VERSION}" -o /since
 
 FROM scratch
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 export CGO_ENABLED ?= 0
 
+VERSION ?= dev
+
 .PHONY: build
 build:
-	go build -o since
+	go build -ldflags="-s -w -X github.com/release-tools/since/cmd.Version=$(VERSION)" -o since
 
 .PHONY: fmt
 fmt:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,8 @@ import (
 	"os"
 )
 
+var Version = "dev"
+
 var rootArgs struct {
 	logLevel string
 	quiet    bool
@@ -38,6 +40,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	cobra.OnInitialize(initLogging)
 
+	rootCmd.Version = Version
 	rootCmd.PersistentFlags().StringVarP(&rootArgs.logLevel, "log-level", "l", "debug", "Log level (debug, info, warn, error, fatal, panic)")
 	rootCmd.PersistentFlags().BoolVarP(&rootArgs.quiet, "quiet", "q", false, "Disable logging (useful for scripting)")
 }


### PR DESCRIPTION
Add support for `since --version` and `since -v` to print the built version of the binary.

## Summary
- Added a `Version` variable in `cmd/root.go` that defaults to `dev` for development builds
- Wired it into Cobra's built-in `--version` / `-v` flag support
- Updated `.goreleaser.yml` to inject the release version via `ldflags -X` during release builds
- Updated `Dockerfile` to accept version as a build arg and inject it
- Updated `Makefile` to support `VERSION` override at build time