### PR TITLE
test: improve coverage of changelog, semver, cfg and vcs core logic

### DIFF
--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cfg
 
 import (
+	"os"
+	"path"
 	"reflect"
 	"testing"
 )
@@ -61,5 +63,33 @@ func Test_loadConfig(t *testing.T) {
 				t.Errorf("loadConfig() got = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	dir := t.TempDir()
+	content := "requireBranch: main\nbefore:\n  - command: echo\n    args:\n      - hello world\n"
+	if err := os.WriteFile(path.Join(dir, defaultConfigFile), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	want := SinceConfig{RequireBranch: "main", Before: []Hook{{Command: "echo", Args: []string{"hello world"}}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("LoadConfig() got = %v, want %v", got, want)
+	}
+}
+
+func TestLoadConfig_missingFile(t *testing.T) {
+	// a directory with no since.yaml should yield an empty config, not an error
+	got, err := LoadConfig(t.TempDir())
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, SinceConfig{}) {
+		t.Errorf("LoadConfig() got = %v, want empty config", got)
 	}
 }

--- a/changelog/changelog_test.go
+++ b/changelog/changelog_test.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -301,6 +302,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 				t.Errorf("GetUpdatedChangelog() gotUpdatedChangelog = %v, want %v", gotUpdatedChangelog, tt.wantUpdatedChangelog)
 			}
 		})
+	}
+}
+
+func TestInitChangelog(t *testing.T) {
+	repoDir := createTestRepo(t)
+	// add an unreleased commit so there are changes to render
+	commitChange(t, repoDir, "README.md", "unreleased\r\n", "feat: unreleased change", time.Now())
+
+	changelogFile := path.Join(repoDir, "CHANGELOG.md")
+
+	updated, err := InitChangelog(cfg.SinceConfig{}, vcs.CommitConfig{}, changelogFile, vcs.TagOrderSemver, repoDir)
+	if err != nil {
+		t.Fatalf("InitChangelog() error = %v", err)
+	}
+
+	// the rendered changelog should retain the boilerplate header and contain
+	// at least one version section
+	if !strings.HasPrefix(updated, "# Changelog") {
+		t.Errorf("InitChangelog() output missing boilerplate header, got: %q", updated)
+	}
+	if !strings.Contains(updated, "## [") {
+		t.Errorf("InitChangelog() output missing version section, got: %q", updated)
+	}
+
+	// the file written to disk should match the returned content (with the
+	// trailing newline WriteChangelog appends)
+	onDisk, err := os.ReadFile(changelogFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(onDisk) != updated+"\n" {
+		t.Errorf("InitChangelog() file content = %q, want %q", string(onDisk), updated+"\n")
 	}
 }
 

--- a/changelog/errors_test.go
+++ b/changelog/errors_test.go
@@ -1,0 +1,39 @@
+package changelog
+
+import "testing"
+
+func TestNoChangesError_Error(t *testing.T) {
+	tests := []struct {
+		name string
+		err  NoChangesError
+		want string
+	}{
+		{
+			name: "excluded commits with start tag",
+			err:  NoChangesError{StartTag: "0.1.0", ExcludedCount: 3},
+			want: "no eligible commits since 0.1.0 — 3 commit(s) were excluded by ignore patterns in since.yaml",
+		},
+		{
+			name: "excluded commits without start tag",
+			err:  NoChangesError{ExcludedCount: 2},
+			want: "no eligible commits found — 2 commit(s) were excluded by ignore patterns in since.yaml",
+		},
+		{
+			name: "start tag with no exclusions",
+			err:  NoChangesError{StartTag: "1.2.3"},
+			want: "no commits since 1.2.3",
+		},
+		{
+			name: "no start tag and no exclusions",
+			err:  NoChangesError{},
+			want: "no commits found",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/changelog/read_test.go
+++ b/changelog/read_test.go
@@ -119,6 +119,71 @@ func TestParseChangelog_withHeader(t *testing.T) {
 	}
 }
 
+func TestParseChangelog_nonExistent(t *testing.T) {
+	_, err := ParseChangelog("/nonexistent/CHANGELOG.md", "1.0.0", false)
+	if err == nil {
+		t.Error("ParseChangelog() expected error for non-existent file")
+	}
+}
+
+func Test_readChanges_versionNotFound(t *testing.T) {
+	lines := []string{
+		"# Changelog",
+		"",
+		"## [1.0.0] - 2024-01-01",
+		"- feat: foo",
+	}
+	_, err := readChanges(lines, "9.9.9", false)
+	if err == nil {
+		t.Fatal("readChanges() expected error for missing version")
+	}
+	want := "could not find version 9.9.9 in changelog"
+	if err.Error() != want {
+		t.Errorf("readChanges() error = %q, want %q", err.Error(), want)
+	}
+}
+
+func Test_readChanges_noVersionSections(t *testing.T) {
+	lines := []string{
+		"# Changelog",
+		"",
+		"All notable changes are documented here.",
+	}
+	_, err := readChanges(lines, "", false)
+	if err == nil {
+		t.Fatal("readChanges() expected error when no version sections present")
+	}
+	want := "changelog contains no version sections"
+	if err.Error() != want {
+		t.Errorf("readChanges() error = %q, want %q", err.Error(), want)
+	}
+}
+
+func Test_readChanges_lastVersionToEndOfFile(t *testing.T) {
+	// trailing empty string mirrors ReadFile splitting a file that ends in a
+	// newline; readChanges relies on it to bound the final section
+	lines := []string{
+		"# Changelog",
+		"",
+		"## [1.0.0] - 2024-01-01",
+		"### Added",
+		"- feat: foo",
+		"",
+		"## [0.9.0] - 2023-12-01",
+		"### Fixed",
+		"- fix: bar",
+		"",
+	}
+	got, err := readChanges(lines, "0.9.0", true)
+	if err != nil {
+		t.Fatalf("readChanges() error = %v", err)
+	}
+	want := []string{"## [0.9.0] - 2023-12-01", "### Fixed", "- fix: bar"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("readChanges() = %v, want %v", got, want)
+	}
+}
+
 func Test_readChanges_firstVersion(t *testing.T) {
 	lines := []string{
 		"# Changelog",

--- a/semver/versions_test.go
+++ b/semver/versions_test.go
@@ -16,7 +16,15 @@ limitations under the License.
 
 package semver
 
-import "testing"
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/release-tools/since/vcs"
+)
 
 func TestGetNextVersion(t *testing.T) {
 	type args struct {
@@ -72,6 +80,48 @@ func TestGetNextVersion(t *testing.T) {
 				t.Errorf("GetNextVersion() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestGetCurrentVersion verifies that a "v" prefixed tag is reported with the
+// prefix stripped and vPrefix set. Note: vcs caches the latest tag in a
+// package-level variable that this package cannot reset, so this test performs
+// a single repository lookup to avoid cross-test contamination.
+func TestGetCurrentVersion(t *testing.T) {
+	repoDir := t.TempDir()
+
+	repo, err := git.PlainInit(repoDir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w, err := repo.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(repoDir+"/README.md", []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Add("README.md"); err != nil {
+		t.Fatal(err)
+	}
+	sig := &object.Signature{Name: "user", Email: "user@example.com", When: time.Now()}
+	c, err := w.Commit("feat: first", &git.CommitOptions{Author: sig, Committer: sig})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.CreateTag("v2.3.4", c, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	version, vPrefix, err := GetCurrentVersion(repoDir, vcs.TagOrderSemver)
+	if err != nil {
+		t.Fatalf("GetCurrentVersion() error = %v", err)
+	}
+	if version != "2.3.4" {
+		t.Errorf("GetCurrentVersion() version = %q, want %q", version, "2.3.4")
+	}
+	if !vPrefix {
+		t.Errorf("GetCurrentVersion() vPrefix = %v, want true", vPrefix)
 	}
 }
 

--- a/vcs/operations_test.go
+++ b/vcs/operations_test.go
@@ -49,6 +49,29 @@ func TestCheckBranch_wrongBranch(t *testing.T) {
 	}
 }
 
+func TestCheckBranch_matchingBranch(t *testing.T) {
+	repoDir := createTestRepo(t)
+
+	// resolve the repo's actual current branch so the test does not depend on
+	// whether go-git initialises HEAD as "master" or "main"
+	branch, err := getCurrentBranch(repoDir)
+	if err != nil {
+		t.Fatalf("getCurrentBranch() error = %v", err)
+	}
+
+	config := cfg.SinceConfig{RequireBranch: branch}
+	if err := CheckBranch(repoDir, config); err != nil {
+		t.Errorf("CheckBranch() on required branch error = %v", err)
+	}
+}
+
+func TestCheckBranch_invalidRepo(t *testing.T) {
+	config := cfg.SinceConfig{RequireBranch: "main"}
+	if err := CheckBranch(t.TempDir(), config); err == nil {
+		t.Error("CheckBranch() expected error for invalid repo")
+	}
+}
+
 func TestCommitChangelog(t *testing.T) {
 	repoDir := createTestRepo(t)
 


### PR DESCRIPTION
Add targeted tests for previously untested core logic across the changelog, semver, cfg and vcs packages.

## Summary
- Cover `NoChangesError.Error` across all four message branches
- Add changelog read error paths (missing version, no version sections, non-existent file) and the last-section-to-end-of-file boundary
- Test `cfg.LoadConfig` directory wrapper and its missing-file behaviour
- Verify `semver.GetCurrentVersion` strips the `v` prefix and sets the prefix flag
- Cover `vcs.CheckBranch` matching-branch and invalid-repo paths
- Add an end-to-end `changelog.InitChangelog` test asserting written content matches disk

## Implementation details
The `vcs` package caches the earliest/latest tag in package-level variables that other packages cannot reset, so the new `semver` test performs a single repository lookup to avoid cross-test contamination, and `CheckBranch` resolves the repo's actual current branch rather than hard-coding `master`/`main`. The last-section read test deliberately includes a trailing empty line, mirroring how `ReadFile` splits a file ending in a newline — `readChanges` relies on that to bound the final section. All tests pass under `-shuffle=on`.